### PR TITLE
Using WINUSB_MS_VENDOR_CODE in extra string

### DIFF
--- a/src/winusb.c
+++ b/src/winusb.c
@@ -78,7 +78,8 @@ static void winusb_set_config(usbd_device* usbd_dev, uint16_t wValue) {
 }
 
 void winusb_setup(usbd_device* usbd_dev) {
-    usbd_register_extra_string(usbd_dev, 0xEE, "MSFT100!");
+    static const char msft_extra_string[] = {'M', 'S', 'F', 'T', '1', '0', '0', WINUSB_MS_VENDOR_CODE, '\0'};
+    usbd_register_extra_string(usbd_dev, 0xEE, msft_extra_string);
     usbd_register_set_config_callback(usbd_dev, winusb_set_config);
 
     /* Windows probes the compatible ID before setting the configuration,


### PR DESCRIPTION
This might make some future debugging easier.

I did *not* test this, but it should work in theory :)