### PR TITLE
Fix issue #15, add attribute to avoid a warning by GCC

### DIFF
--- a/src/dfu.c
+++ b/src/dfu.c
@@ -231,6 +231,7 @@ static int dfu_control_class_request(usbd_device *usbd_dev,
                 case STATE_DFU_IDLE: {
                     current_dfu_offset = 0;
                     /* Fall through */
+                    __attribute__ ((fallthrough));
                 }
                 case STATE_DFU_UPLOAD_IDLE: {
                     *buf = (uint8_t*)(APP_BASE_ADDRESS + current_dfu_offset);


### PR DESCRIPTION
As mentioned in the issue #15, added an attribute to avoid GCC issue a warning regarding a fall through.