### PR TITLE
Don't compile all of libopencm3, only required target

### DIFF
--- a/src/rules.mk
+++ b/src/rules.mk
@@ -34,6 +34,7 @@ ifeq ($(ARCH),STM32F0)
 	FP_FLAGS   ?= -msoft-float
 	ARCH_FLAGS  = -mthumb -mcpu=cortex-m0 $(FP_FLAGS)
 	OOCD_BOARD ?= target/stm32f0x.cfg
+	OPENCM3_TARGET = "stm32/f0"
 endif
 ifeq ($(ARCH),STM32F1)
 	LIBNAME     = opencm3_stm32f1
@@ -41,12 +42,14 @@ ifeq ($(ARCH),STM32F1)
 	FP_FLAGS   ?= -msoft-float
 	ARCH_FLAGS  = -mthumb -mcpu=cortex-m3 $(FP_FLAGS) -mfix-cortex-m3-ldrd
 	OOCD_BOARD ?= target/stm32f1x.cfg
+	OPENCM3_TARGET = "stm32/f1"
 endif
 
 LIBNAME        ?= opencm3_stm32f0
 DEFS           ?= -DSTM32F0
 FP_FLAGS       ?= -msoft-float
 ARCH_FLAGS     ?= -mthumb -mcpu=cortex-m0 $(FP_FLAGS)
+OPENCM3_TARGET ?= "stm32/f0"
 
 ####################################################################
 # Semihosting support
@@ -156,7 +159,7 @@ $(OPENCM3_DIR)/Makefile:
 	$(Q)git submodule update --init $(OPENCM3_DIR)
 
 $(LIB_DIR)/lib$(LIBNAME).a: $(OPENCM3_DIR)/Makefile
-	$(Q)$(MAKE) -C $(OPENCM3_DIR)
+	$(Q)$(MAKE) -C $(OPENCM3_DIR) TARGETS=$(OPENCM3_TARGET)
 
 locm3: $(LIB_DIR)/lib$(LIBNAME).a
 


### PR DESCRIPTION
There is no need to build all of libopencm3 if we know the target.