### PR TITLE
Use BOOT1 as bootloader enter button in bluepill board.

### DIFF
--- a/src/stm32f103/bluepill/config.h
+++ b/src/stm32f103/bluepill/config.h
@@ -49,7 +49,20 @@
 #endif
 
 #ifndef HAVE_BUTTON
-#define HAVE_BUTTON 0
+#define HAVE_BUTTON 1
+#endif
+#ifndef BUTTON_ACTIVE_HIGH
+#define BUTTON_ACTIVE_HIGH 1
+#endif
+#ifndef BUTTON_GPIO_PORT
+#define BUTTON_GPIO_PORT GPIOB
+#endif
+#ifndef BUTTON_GPIO_PIN
+#define BUTTON_GPIO_PIN GPIO2
+#endif
+// Blue-Pull has 100k resistors on PB2, so we can't use weak pulls to read it.
+#ifndef BUTTON_USES_PULL
+#define BUTTON_USES_PULL 0
 #endif
 
 #ifndef BUTTON_SAMPLE_DELAY_CYCLES
@@ -58,6 +71,10 @@
 
 #ifndef HAVE_USB_PULLUP_CONTROL
 #define HAVE_USB_PULLUP_CONTROL 0
+#endif
+
+#ifndef USES_GPIOB
+#define USES_GPIOB 1
 #endif
 
 #ifndef USES_GPIOC

--- a/src/stm32f103/target_stm32f103.c
+++ b/src/stm32f103/target_stm32f103.c
@@ -45,6 +45,10 @@
 #define USES_GPIOC 0
 #endif
 
+#ifndef BUTTON_USES_PULL
+#define BUTTON_USES_PULL 1
+#endif
+
 #ifdef FLASH_SIZE_OVERRIDE
 _Static_assert((FLASH_BASE + FLASH_SIZE_OVERRIDE >= APP_BASE_ADDRESS),
                "Incompatible flash size");
@@ -95,12 +99,15 @@ void target_gpio_setup(void) {
 #if HAVE_BUTTON
     {
         const uint8_t mode = GPIO_MODE_INPUT;
-        const uint8_t conf = GPIO_CNF_INPUT_PULL_UPDOWN;
+        const uint8_t conf = (BUTTON_USES_PULL ? GPIO_CNF_INPUT_PULL_UPDOWN
+                                               : GPIO_CNF_INPUT_FLOAT);
         gpio_set_mode(BUTTON_GPIO_PORT, mode, conf, BUTTON_GPIO_PIN);
-        if (BUTTON_ACTIVE_HIGH) {
-            gpio_clear(BUTTON_GPIO_PORT, BUTTON_GPIO_PIN);
-        } else {
-            gpio_set(BUTTON_GPIO_PORT, BUTTON_GPIO_PIN);
+        if (BUTTON_USES_PULL) {
+            if (BUTTON_ACTIVE_HIGH) {
+                gpio_clear(BUTTON_GPIO_PORT, BUTTON_GPIO_PIN);
+            } else {
+                gpio_set(BUTTON_GPIO_PORT, BUTTON_GPIO_PIN);
+            }
         }
     }
 #endif


### PR DESCRIPTION
The bluepill board has a dip-switch connected to BOOT1 (PB2) via a 100k resistor.

This allows entering the bootloader when connecting the switch to "1".
