### PR TITLE
dfu: support "detach"

### DIFF
--- a/src/dfu.c
+++ b/src/dfu.c
@@ -19,6 +19,7 @@
 #include <stdlib.h>
 #include <string.h>
 
+#include <libopencm3/cm3/scb.h>
 #include <libopencm3/cm3/vector.h>
 #include <libopencm3/usb/usbd.h>
 #include <libopencm3/usb/dfu.h>
@@ -294,6 +295,11 @@ static int dfu_control_class_request(usbd_device *usbd_dev,
         }
 #endif
         case DFU_DETACH:
+            /* Best we can do! */
+            scb_reset_system();
+            status = USBD_REQ_HANDLED;
+            break;
+
         default: {
             /* Stall the control pipe */
             dfu_set_status(DFU_STATUS_ERR_STALLEDPKT);


### PR DESCRIPTION
When in DFU mode, the only way to exit was via a download operation.
"dfu-util -e" to request a detach was simply not supported, so the
bootloader simply remains sitting there
Handle detach via reboot, the usb layer will re-enumerate if it can,
and will boot app/bl based on it's own decisions.

Signed-off-by: Karl Palsson <karlp@tweak.net.au>

-- 
this might be me not having used dfu a lot?  Is there something I missed?