### PR TITLE
l1: avoid warnings on "abuse" of .data subsections

### DIFF
--- a/src/stm32l1/stm32l1-base.ld
+++ b/src/stm32l1/stm32l1-base.ld
@@ -83,6 +83,7 @@ SECTIONS
 	.data : {
 		_data = .;
 		*(.data*)	/* Read-write initialized data */
+		*(.ramtext*)	/* code, that needs to be in ram */
 		. = ALIGN(4);
 		_edata = .;
 	} >ram AT >rom

--- a/src/stm32l1/target_stm32l1.c
+++ b/src/stm32l1/target_stm32l1.c
@@ -148,7 +148,7 @@ static void flash_erase_page(uint32_t page_address)
  * than 64MB away from flash address space, must be a long_call.
  * (see https://gcc.gnu.org/bugzilla/show_bug.cgi?id=78903 for noinline) */
 void flash_program_half_page(uint32_t *dst, const uint32_t *buf);
-__attribute__ ((noinline, long_call, section (".data.ramfunctions")))
+__attribute__ ((noinline, long_call, section (".ramtext")))
 void flash_program_half_page(uint32_t *dst, const uint32_t *buf)
 {
         const uint32_t *src = buf;


### PR DESCRIPTION
Somewhere, gcc probably has a footnote about how .data* is treated
specially, but I can't find it.  Introduce a special section that
doesn't start with .data and presto, the assembler warnings go away.

anyway, this fixes the warnings...