### PR TITLE
Allow configuration of VID/PID without hacking up the source code

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,12 @@ This bootloader implements the draft [WebUSB](https://wicg.github.io/webusb/) sp
 For a demo implementing dfu-util features in the browser, see https://devanlai.github.io/webdfu/dfu-util/
 
 ## USB VID/PID
-The USB VID/PID pair ([1209/DB42](http://pid.codes/1209/DB42/)) is allocated through the [pid.codes](http://pid.codes/) open-source USB PID program.
+The default USB VID/PID pair ([1209/DB42](http://pid.codes/1209/DB42/)) is allocated through the [pid.codes](http://pid.codes/) open-source USB PID program.
+
+To use a custom VID/PID pair, you need to set the macros `USB_VID` and `USB_PID`. One way to do this is by setting the `DEFS` environment variable when compiling:
+
+     DEFS="-DUSB_VID=0x1209 -DUSB_PID=0xCAFE" make
+
 
 ## Licensing
 All contents of the dapboot project are licensed under terms that are compatible with the terms of the GNU Lesser General Public License version 3.

--- a/src/usb_conf.h
+++ b/src/usb_conf.h
@@ -21,8 +21,14 @@
 
 #include <libopencm3/usb/usbd.h>
 
+#ifndef USB_VID
 #define USB_VID                 0x1209
+#endif
+
+#ifndef USB_PID
 #define USB_PID                 0xdb42
+#endif
+
 #define USB_CONTROL_BUF_SIZE    1024
 #define USB_SERIAL_NUM_LENGTH   24
 #define INTF_DFU                0


### PR DESCRIPTION
I'm starting to look at using dapboot in a new product. To do this, we're going to want to use our own VID/PID pair. 

This PR makes it possible to change the VID/PID without editing the source code of dapboot.

I'm happy to revise it to meet house style.