### PR TITLE
toolchain helper macos support

### DIFF
--- a/util/install-toolchain.sh
+++ b/util/install-toolchain.sh
@@ -27,12 +27,14 @@ if [ $TOOLCHAIN_MISSING -eq 1 ]; then
     ln -s $TOOLCHAIN ${TOOLCHAINS}/gcc-arm-embedded
 fi;
 
-EXISTING_TOOLCHAIN=`readlink -f "${TOOLCHAINS}/gcc-arm-embedded"`
+EXISTING_TOOLCHAIN=`readlink "${TOOLCHAINS}/gcc-arm-embedded"`
 echo "Current toolchain is $EXISTING_TOOLCHAIN"
 
+if [ $TOOLCHAIN_ARCH != 'mac' ]; then
 if ! ldd ${GCC} >/dev/null; then
     echo "${GCC} does not appear to be executable on this machine"
     exit 1
+fi;
 fi;
 
 TOOLCHAIN_VER=`${GCC} --version | head -n 1`

--- a/util/install-toolchain.sh
+++ b/util/install-toolchain.sh
@@ -1,7 +1,14 @@
 #!/bin/bash
 set -eo pipefail
-URL=https://developer.arm.com/-/media/Files/downloads/gnu-rm/9-2019q4/gcc-arm-none-eabi-9-2019-q4-major-x86_64-linux.tar.bz2
+
+if [ `uname` == 'Darwin' ]; then
+TOOLCHAIN_ARCH=mac
+else
+TOOLCHAIN_ARCH=x86_64-linux
+fi
+TOOLCHAIN_REV=9-2019q4
 TOOLCHAIN=gcc-arm-none-eabi-9-2019-q4-major
+URL=https://developer.arm.com/-/media/Files/downloads/gnu-rm/${TOOLCHAIN_REV}/${TOOLCHAIN}-${TOOLCHAIN_ARCH}.tar.bz2
 TOOLCHAINS=$HOME/toolchains
 TOOLCHAIN_MISSING=0
 GCC=${TOOLCHAINS}/gcc-arm-embedded/bin/arm-none-eabi-gcc


### PR DESCRIPTION
A tiny hackjob on the toolchain helper that lets it fetch the macos version of the toolchain from arm