### PR TITLE
Allow more flexibility when configuring from config.h

### DIFF
--- a/src/dapboot.c
+++ b/src/dapboot.c
@@ -21,11 +21,11 @@
 
 #include "dapboot.h"
 #include "target.h"
+#include "config.h"
 #include "usb_conf.h"
 #include "dfu.h"
 #include "webusb.h"
 #include "winusb.h"
-#include "config.h"
 
 static inline void __set_MSP(uint32_t topOfMainStack) {
     asm("msr msp, %0" : : "r" (topOfMainStack));

--- a/src/dfu.c
+++ b/src/dfu.c
@@ -25,11 +25,11 @@
 #include <libopencm3/usb/dfu.h>
 
 #include "dfu.h"
+#include "config.h"
 #include "usb_conf.h"
 #include "dfu_defs.h"
 #include "target.h"
 #include "dapboot.h"
-#include "config.h"
 
 #ifndef TARGET_DFU_WTRANSFERSIZE
 #define TARGET_DFU_WTRANSFERSIZE USB_CONTROL_BUF_SIZE

--- a/src/usb_conf.c
+++ b/src/usb_conf.c
@@ -25,6 +25,7 @@
 #include "dfu.h"
 #include "webusb.h"
 
+#include "config.h"
 #include "usb_conf.h"
 
 static const struct usb_device_descriptor dev = {

--- a/src/webusb.c
+++ b/src/webusb.c
@@ -19,8 +19,8 @@
 #include <libopencm3/usb/usbd.h>
 #include "webusb.h"
 
-#include "usb_conf.h"
 #include "config.h"
+#include "usb_conf.h"
 
 #ifndef LANDING_PAGE_URL
 #define LANDING_PAGE_URL "devanlai.github.io/webdfu/dfu-util/"

--- a/src/winusb.c
+++ b/src/winusb.c
@@ -19,6 +19,7 @@
 #include <libopencm3/usb/usbd.h>
 #include "winusb.h"
 
+#include "config.h"
 #include "usb_conf.h"
 
 static const struct winusb_compatible_id_descriptor winusb_wcid = {


### PR DESCRIPTION
In order to be able to override the VID and PID for a device from inside
its config.h, config.h needs to be included before usb_conf.h

This lets you stick something like this in config.h and have it 'just work'

```

#define USB_VID 0x1209
#define USB_PID 0x2306

#define INNER_STRINGIFY(str) #str
#define STRINGIFY(str) INNER_STRINGIFY(str)

#define LANDING_PAGE_URL "dfu.keyboard.io?vid=" STRINGIFY(USB_VID) ";pid=" STRINGIFY(USB_PID)  ";version=" STRINGIFY(GIT_BUILD_SHA)

```

* GIT_BUILD_SHA needs one more line in the Makefile or for it to be passed in on the commandline