### PR TITLE
Fix detach request callback being treated as manifest request callback

### DIFF
--- a/src/dapboot.c
+++ b/src/dapboot.c
@@ -75,7 +75,7 @@ int main(void) {
         }
 
         usbd_device* usbd_dev = usb_setup();
-        dfu_setup(usbd_dev, NULL, NULL, NULL);
+        dfu_setup(usbd_dev, target_manifest_app, NULL, NULL);
         webusb_setup(usbd_dev);
         winusb_setup(usbd_dev);
         

--- a/src/dapboot.c
+++ b/src/dapboot.c
@@ -75,7 +75,7 @@ int main(void) {
         }
 
         usbd_device* usbd_dev = usb_setup();
-        dfu_setup(usbd_dev, &target_manifest_app, NULL, NULL);
+        dfu_setup(usbd_dev, NULL, NULL, NULL);
         webusb_setup(usbd_dev);
         winusb_setup(usbd_dev);
         

--- a/src/dapboot.c
+++ b/src/dapboot.c
@@ -32,10 +32,7 @@ static inline void __set_MSP(uint32_t topOfMainStack) {
 }
 
 bool validate_application(void) {
-    if (((uint32_t)(APP_INITIAL_STACK) & 0x2FFE0000) == 0x20000000) {
-        return true;
-    }
-    return false;
+    return ((uint32_t)(APP_INITIAL_STACK) & 0x2FFE0000) == 0x20000000;
 }
 
 static void jump_to_application(void) __attribute__ ((noreturn));
@@ -75,7 +72,7 @@ int main(void) {
         }
 
         usbd_device* usbd_dev = usb_setup();
-        dfu_setup(usbd_dev, target_manifest_app, NULL, NULL);
+        dfu_setup(usbd_dev, validate_application, NULL, NULL);
         webusb_setup(usbd_dev);
         winusb_setup(usbd_dev);
         

--- a/src/dfu.h
+++ b/src/dfu.h
@@ -29,12 +29,12 @@
 
 extern const struct usb_dfu_descriptor dfu_function;
 
-typedef void (*GenericCallback)(void);
+typedef bool (*ManifestationCallback)(void);
 typedef void (*StateChangeCallback)(enum dfu_state);
 typedef void (*StatusChangeCallback)(enum dfu_status);
 
 extern void dfu_setup(usbd_device* usbd_dev,
-                      GenericCallback on_manifest_request,
+                      ManifestationCallback on_manifest_request,
                       StateChangeCallback on_state_change,
                       StatusChangeCallback on_status_change);
 

--- a/src/dfu.h
+++ b/src/dfu.h
@@ -22,6 +22,11 @@
 #include <libopencm3/usb/usbd.h>
 #include <libopencm3/usb/dfu.h>
 
+// For WebUSB compatibility
+#ifndef DFU_WILL_DETACH
+#define DFU_WILL_DETACH 1
+#endif
+
 extern const struct usb_dfu_descriptor dfu_function;
 
 typedef void (*GenericCallback)(void);

--- a/src/dfu.h
+++ b/src/dfu.h
@@ -29,7 +29,7 @@ typedef void (*StateChangeCallback)(enum dfu_state);
 typedef void (*StatusChangeCallback)(enum dfu_status);
 
 extern void dfu_setup(usbd_device* usbd_dev,
-                      GenericCallback on_detach_request,
+                      GenericCallback on_manifest_request,
                       StateChangeCallback on_state_change,
                       StatusChangeCallback on_status_change);
 

--- a/src/usb_conf.c
+++ b/src/usb_conf.c
@@ -22,11 +22,11 @@
 
 #include <libopencm3/usb/dfu.h>
 #include "target.h"
-#include "dfu.h"
 #include "webusb.h"
 
 #include "config.h"
 #include "usb_conf.h"
+#include "dfu.h"
 
 static const struct usb_device_descriptor dev = {
     .bLength = USB_DT_DEVICE_SIZE,


### PR DESCRIPTION
Hello @devanlai! :wave: First of all thank you for creating dapboot and dap42, these have been invaluable tools in establishing a modern embedded debugging workflow. Over the past days I've put in some work to have dapboot replace a proprietary bootloader solution on a STM32F103-based board, but its flashing system and firmware required some options/flexibility not currently present in dapboot. In order to contribute back to this awesome project I've managed to implement these features, such as per-target backup register and magic value overrides for entering the bootloader and alternate setting support (as described [here](https://www.beyondlogic.org/usbnutshell/usb5.shtml)) for the exposed USB DFU interface. Together with the new board support (it has 256 KiB flash, I've added a high memory option for that as well) this is quite a large changeset, so I'll split it up into small(ish) PRs for easier review. While working on the bootloader I also uncovered and fixed some bugs, with these fixes for example [dfu-util](http://dfu-util.sourceforge.net/) no longer throws errors after flashing (which stopped the update mechanism of the new board I was working on).

First one: For the `dfu_setup` function there is a callback called `on_manifest_request`, which in the header was called `on_detach_request`. Subsequently `target_manifest_app` (which acts as a detach callback, resetting the whole MCU) was passed in as a manifest callback and the board reset itself every time "dfuMANIFEST-SYNC" was supposed to complete. I have fixed the naming discrepancy by assuming that the callback was meant to be `on_manifest_request`, as that is how it's being used in `dfu.c`. This prevents the bootloader from detaching prematurely after download and makes it compliant with the [DFU 1.1 spec](https://www.usb.org/sites/default/files/DFU_1.1.pdf) (chapter 7. Manifestation Phase). Additionally many flashing routines do not expect an automatic detach, so I've assumed the DFU spec option to return to idle after download as what was originally intended (an automatic reset can still be achieved by passing the -R flag to dfu-util for example), in other words the bootloader was intended to have the `USB_DFU_MANIFEST_TOLERANT` attribute since there is no usage of `STATE_DFU_MANIFEST_WAIT_RESET` in the code.

Confirmed working with dfu-util 0.9 and 0.10 when flashing an STM32F103RC.