### PR TITLE
Fix RTC backup register indexing, add target-specific register and boot command

### DIFF
--- a/src/stm32f103/backup.c
+++ b/src/stm32f103/backup.c
@@ -29,13 +29,13 @@ void backup_write(enum BackupRegister reg, uint32_t value) {
     rcc_periph_clock_enable(RCC_BKP);
 
     pwr_disable_backup_domain_write_protect();
-    RTC_BKP_DR((int)reg*2) = value & 0xFFFFUL;
-    RTC_BKP_DR((int)reg*2+1) = (value & 0xFFFF0000UL) >> 16;
+    RTC_BKP_DR((int)reg) = value & 0xFFFFUL;
+    RTC_BKP_DR((int)reg+1) = (value & 0xFFFF0000UL) >> 16;
     pwr_enable_backup_domain_write_protect();
 }
 
 uint32_t backup_read(enum BackupRegister reg) {
-    uint32_t value = ((uint32_t)RTC_BKP_DR((int)reg*2+1) << 16)
-                   | ((uint32_t)RTC_BKP_DR((int)reg*2) << 0);
+    uint32_t value = (uint32_t)RTC_BKP_DR((int)reg)
+                   | ((uint32_t)RTC_BKP_DR((int)reg+1) << 16);
     return value;
 }

--- a/src/stm32f103/backup.c
+++ b/src/stm32f103/backup.c
@@ -24,18 +24,15 @@
 
 #define RTC_BKP_DR(reg)  MMIO16(BACKUP_REGS_BASE + 4 + (4 * (reg)))
 
-void backup_write(enum BackupRegister reg, uint32_t value) {
+void backup_write(enum BackupRegister reg, uint16_t value) {
     rcc_periph_clock_enable(RCC_PWR);
     rcc_periph_clock_enable(RCC_BKP);
 
     pwr_disable_backup_domain_write_protect();
-    RTC_BKP_DR((int)reg) = value & 0xFFFFUL;
-    RTC_BKP_DR((int)reg+1) = (value & 0xFFFF0000UL) >> 16;
+    RTC_BKP_DR((int)reg) = value;
     pwr_enable_backup_domain_write_protect();
 }
 
-uint32_t backup_read(enum BackupRegister reg) {
-    uint32_t value = (uint32_t)RTC_BKP_DR((int)reg)
-                   | ((uint32_t)RTC_BKP_DR((int)reg+1) << 16);
-    return value;
+uint16_t backup_read(enum BackupRegister reg) {
+    return RTC_BKP_DR((int)reg);
 }

--- a/src/stm32f103/backup.h
+++ b/src/stm32f103/backup.h
@@ -32,7 +32,7 @@ enum BackupRegister {
     BKP10,
 };
 
-extern void backup_write(enum BackupRegister reg, uint32_t value);
-extern uint32_t backup_read(enum BackupRegister reg);
+extern void backup_write(enum BackupRegister reg, uint16_t value);
+extern uint16_t backup_read(enum BackupRegister reg);
 
 #endif

--- a/src/stm32f103/backup.h
+++ b/src/stm32f103/backup.h
@@ -20,11 +20,16 @@
 #define BACKUP_H_INCLUDED
 
 enum BackupRegister {
-    BKP0 = 0,
     BKP1,
     BKP2,
     BKP3,
     BKP4,
+    BKP5,
+    BKP6,
+    BKP7,
+    BKP8,
+    BKP9,
+    BKP10,
 };
 
 extern void backup_write(enum BackupRegister reg, uint32_t value);

--- a/src/stm32f103/target_stm32f103.c
+++ b/src/stm32f103/target_stm32f103.c
@@ -55,7 +55,13 @@ _Static_assert((FLASH_BASE + FLASH_SIZE_OVERRIDE >= APP_BASE_ADDRESS),
                "Incompatible flash size");
 #endif
 
-static const uint32_t CMD_BOOT = 0x544F4F42UL;
+#ifndef REG_BOOT
+#define REG_BOOT BKP1
+#endif
+
+#ifndef CMD_BOOT
+#define CMD_BOOT 0x544F4F42UL
+#endif
 
 void target_clock_setup(void) {
 #ifdef USE_HSI
@@ -160,13 +166,13 @@ const usbd_driver* target_usb_init(void) {
 bool target_get_force_bootloader(void) {
     bool force = false;
     /* Check the RTC backup register */
-    uint32_t cmd = backup_read(BKP0);
+    uint32_t cmd = backup_read(REG_BOOT);
     if (cmd == CMD_BOOT) {
         force = true;
     }
 
     /* Clear the RTC backup register */
-    backup_write(BKP0, 0);
+    backup_write(REG_BOOT, 0);
 
 #if HAVE_BUTTON
     /* Wait some time in case the button has some debounce capacitor */

--- a/src/stm32f103/target_stm32f103.c
+++ b/src/stm32f103/target_stm32f103.c
@@ -60,7 +60,7 @@ _Static_assert((FLASH_BASE + FLASH_SIZE_OVERRIDE >= APP_BASE_ADDRESS),
 #endif
 
 #ifndef CMD_BOOT
-#define CMD_BOOT 0x544F4F42UL
+#define CMD_BOOT 0x4F42UL
 #endif
 
 void target_clock_setup(void) {
@@ -166,7 +166,7 @@ const usbd_driver* target_usb_init(void) {
 bool target_get_force_bootloader(void) {
     bool force = false;
     /* Check the RTC backup register */
-    uint32_t cmd = backup_read(REG_BOOT);
+    uint16_t cmd = backup_read(REG_BOOT);
     if (cmd == CMD_BOOT) {
         force = true;
     }

--- a/src/stm32l1/target_stm32l1.c
+++ b/src/stm32l1/target_stm32l1.c
@@ -27,8 +27,15 @@
 #include "config.h"
 #include "backup.h"
 
+#ifndef REG_BOOT
+#define REG_BOOT BKP1
+#endif
+
+#ifndef CMD_BOOT
+#define CMD_BOOT 0x544F4F42UL
+#endif
+
 //#define CMD_FAST_BOOT 0xfa57b007
-static const uint32_t CMD_BOOT = 0x544F4F42UL;
 
 void target_clock_setup(void) {
 
@@ -82,11 +89,11 @@ const usbd_driver* target_usb_init(void)
 bool target_get_force_bootloader(void)
 {
 	bool enter_bl = false;
-	uint32_t cmd = backup_read(BKP0);
+	uint32_t cmd = backup_read(REG_BOOT);
 	if (cmd == CMD_BOOT) {
 		enter_bl = true;
 	}
-	backup_write(BKP0, 0);
+	backup_write(REG_BOOT, 0);
 
 #if HAVE_BUTTON
 #warning HAVE_BUTTON not implemented for L1


### PR DESCRIPTION
Continuation of my bug hunting and feature implementation round started in #41.

According to ST's [RM0008 STM32F103xx reference manual](https://www.st.com/resource/en/reference_manual/cd00171190-stm32f101xx-stm32f102xx-stm32f103xx-stm32f105xx-and-stm32f107xx-advanced-arm-based-32-bit-mcus-stmicroelectronics.pdf) section 6.4.5 table 17 the backup registers are 32 bits wide with only the lower 16 bits being used for storing values. In addition to this, the "first" register slot is entirely reserved and there is no backup register zero, meaning that `BKP_DR1` starts from an offset of 0x04. This was mostly correctly reflected in `backup.c`, but the 2-multiplier for the register enum throws everything off by a lot, which results in the boot command check failing to work correctly when using anything but the first backup register. `BKP0` has also been removed since as described by RM0008 indexing starts at one (`BKP1` is now fully equivalent to the old `BKP0`).

I've also gone ahead and implemented support for specifying the backup register and boot command to use per-target. If not defined, options equivalent to the old behavior are used to not break existing applications.