### PR TITLE
Add a new 'target_post_setup' hook that targets can use for their own custom initialization

### DIFF
--- a/src/dapboot.c
+++ b/src/dapboot.c
@@ -75,7 +75,8 @@ int main(void) {
         dfu_setup(usbd_dev, validate_application, NULL, NULL);
         webusb_setup(usbd_dev);
         winusb_setup(usbd_dev);
-        
+        target_post_setup();
+
         while (1) {
             usbd_poll(usbd_dev);
         }

--- a/src/dummy.c
+++ b/src/dummy.c
@@ -26,6 +26,7 @@ void target_get_serial_number(char* dest, size_t max_chars) __attribute__((weak)
 void target_log(const char* str) __attribute__((weak));
 void target_pre_main(void) __attribute__((weak));
 void target_pre_detach(bool manifested) __attribute__((weak));
+void target_post_setup(void) __attribute__((weak));
 size_t target_get_timeout(void) __attribute__((weak));
 
 void target_get_serial_number(char* dest, size_t max_chars) {
@@ -43,6 +44,12 @@ void target_pre_main(void)
 {
 
 }
+
+void target_post_setup(void)
+{
+	/* This runs just before starting to listen to USB */
+}
+
 
 void target_pre_detach(bool manifested) {
     /* This runs just before executing a reboot in response to a USB bus reset

--- a/src/target.h
+++ b/src/target.h
@@ -36,6 +36,7 @@ extern void target_flash_lock(void);
 extern bool target_flash_program_array(uint16_t* dest, const uint16_t* data, size_t half_word_count);
 
 extern void target_pre_main(void);
+extern void target_post_setup(void);
 extern void target_pre_detach(bool manifested);
 extern size_t target_get_timeout(void);
 


### PR DESCRIPTION
I find myself in need of a hook to initialize a custom i2c device before USB connect. This hook would let me do that more cleanly.