### PR TITLE
Add support of stm32f103c6 devices

### DIFF
--- a/release.Makefile
+++ b/release.Makefile
@@ -35,6 +35,7 @@ all: dapboot-bluepill.bin \
      dapboot-olimexstm32h103.bin \
      dapboot-bluepillplusstm32.bin \
      dapboot-bttskrminie3v2.bin \
+     dapboot-daplink_f103c6.bin \
      dapboot-bluepill-high.bin \
      dapboot-maplemini-high.bin \
      dapboot-stlink-high.bin \
@@ -91,6 +92,13 @@ dapboot-bttskrminie3v2.bin: | $(BUILD_DIR)
 	$(Q)$(MAKE) TARGET=BTTSKRMINIE3V2 -C src/ clean
 	$(Q)$(MAKE) TARGET=BTTSKRMINIE3V2 -C src/
 	$(Q)cp src/dapboot.bin $(BUILD_DIR)/$(@)
+
+dapboot-daplink_f103c6.bin: | $(BUILD_DIR)
+	@printf "  BUILD $(@)\n"
+	$(Q)$(MAKE) TARGET=DAPLINK_F103C6 -C src/ clean
+	$(Q)$(MAKE) TARGET=DAPLINK_F103C6 -C src/ dapboot_full.bin
+	$(Q)cp src/dapboot.bin $(BUILD_DIR)/$(@)
+	$(Q)cp src/dapboot_full.bin $(BUILD_DIR)/$$(echo $@|sed -e 's/.bin/_full.bin/')
 
 dapboot-bluepill-high.bin: | $(BUILD_DIR)
 	@printf "  BUILD $(@)\n"

--- a/src/dapboot.c
+++ b/src/dapboot.c
@@ -18,6 +18,7 @@
 
 #include <string.h>
 #include <libopencm3/cm3/vector.h>
+#include <libopencm3/cm3/systick.h>
 
 #include "dapboot.h"
 #include "target.h"
@@ -61,6 +62,13 @@ int main(void) {
 
     /* Initialize GPIO/LEDs if needed */
     target_gpio_setup();
+
+#if HAVE_LED
+    systick_set_clocksource(STK_CSR_CLKSOURCE_AHB_DIV8);
+    systick_set_reload(899999);
+    systick_interrupt_enable();
+    systick_counter_enable();
+#endif
 
     if (target_get_force_bootloader() || !validate_application()) {
         /* Setup USB */

--- a/src/dfu.c
+++ b/src/dfu.c
@@ -23,6 +23,7 @@
 #include <libopencm3/cm3/vector.h>
 #include <libopencm3/usb/usbd.h>
 #include <libopencm3/usb/dfu.h>
+#include <libopencm3/stm32/gpio.h>
 
 #include "config.h"
 #include "usb_conf.h"
@@ -395,3 +396,16 @@ void dfu_setup(usbd_device* usbd_dev,
         on_state_change(current_dfu_state);
     }
 }
+
+#if HAVE_LED
+void sys_tick_handler(void)
+{
+    static uint8_t count = 0 ;
+    count ++;
+    if ( count >= ( ( current_dfu_state == STATE_DFU_IDLE ) ? 5 : 1 ) ){
+        count = 0;
+        gpio_toggle(LED_GPIO_PORT, LED_GPIO_PIN);
+    }
+}
+
+#endif

--- a/src/rules.mk
+++ b/src/rules.mk
@@ -58,6 +58,7 @@ DEFS           ?= -DSTM32F0
 FP_FLAGS       ?= -msoft-float
 ARCH_FLAGS     ?= -mthumb -mcpu=cortex-m0 $(FP_FLAGS)
 OPENCM3_TARGET ?= "stm32/f0"
+FLASH_SIZE     ?= 8192
 
 ####################################################################
 # Semihosting support
@@ -177,6 +178,10 @@ locm3: $(LIB_DIR)/lib$(LIBNAME).a
 
 %.images: %.bin %.hex %.srec %.list %.map
 	@#printf "*** $* images generated ***\n"
+
+%_full.bin: %.bin
+	@#printf "  Padding binary to full size"
+	$(Q)dd if=/dev/zero bs=1 count=$$(expr $(FLASH_SIZE) - $$(stat --print "%s" $< )) status=none | LC_CTYPE=C tr '\0' '\377' | cat $< - > $@
 
 %.bin: %.elf
 	@#printf "  OBJCOPY $(*).bin\n"

--- a/src/stm32f103/bluepill/config.h
+++ b/src/stm32f103/bluepill/config.h
@@ -81,4 +81,8 @@
 #define USES_GPIOC 1
 #endif
 
+#ifndef LED_INVERT
+#define LED_INVERT 1
+#endif
+
 #endif

--- a/src/stm32f103/daplink_f103c6/config.h
+++ b/src/stm32f103/daplink_f103c6/config.h
@@ -23,7 +23,7 @@
 #define APP_BASE_ADDRESS (0x08000000 + BOOTLOADER_OFFSET)
 #endif
 #ifndef FLASH_SIZE_OVERRIDE
-#define FLASH_SIZE_OVERRIDE 0x20000
+#define FLASH_SIZE_OVERRIDE 0x08000
 #endif
 #ifndef FLASH_PAGE_SIZE
 #define FLASH_PAGE_SIZE  1024
@@ -38,14 +38,15 @@
 #ifndef HAVE_LED
 #define HAVE_LED 1
 #endif
+#define LED_INVERT
 #ifndef LED_OPEN_DRAIN
-#define LED_OPEN_DRAIN 1
+#define LED_OPEN_DRAIN 0
 #endif
 #ifndef LED_GPIO_PORT
 #define LED_GPIO_PORT GPIOB
 #endif
 #ifndef LED_GPIO_PIN
-#define LED_GPIO_PIN GPIO8
+#define LED_GPIO_PIN GPIO12
 #endif
 
 #ifndef HAVE_BUTTON
@@ -69,9 +70,9 @@
 #define HAVE_USB_PULLUP_CONTROL 0
 #endif
 
-//#ifndef USES_GPIOB
-//#define USES_GPIOB 1
-//#endif
+#ifndef USES_GPIOB
+#define USES_GPIOB 1
+#endif
 //
 //#ifndef USES_GPIOC
 //#define USES_GPIOC 1

--- a/src/stm32f103/daplink_f103c6/config.h
+++ b/src/stm32f103/daplink_f103c6/config.h
@@ -1,0 +1,80 @@
+/*
+ * Copyright (c) 2016, Devan Lai
+ *
+ * Permission to use, copy, modify, and/or distribute this software
+ * for any purpose with or without fee is hereby granted, provided
+ * that the above copyright notice and this permission notice
+ * appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL
+ * WARRANTIES WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE
+ * AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT, INDIRECT, OR
+ * CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
+ * LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT,
+ * NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN
+ * CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ */
+
+#ifndef CONFIG_H_INCLUDED
+#define CONFIG_H_INCLUDED
+
+#ifndef APP_BASE_ADDRESS
+#define APP_BASE_ADDRESS (0x08000000 + BOOTLOADER_OFFSET)
+#endif
+#ifndef FLASH_SIZE_OVERRIDE
+#define FLASH_SIZE_OVERRIDE 0x20000
+#endif
+#ifndef FLASH_PAGE_SIZE
+#define FLASH_PAGE_SIZE  1024
+#endif
+#ifndef DFU_UPLOAD_AVAILABLE
+#define DFU_UPLOAD_AVAILABLE 1
+#endif
+#ifndef DFU_DOWNLOAD_AVAILABLE
+#define DFU_DOWNLOAD_AVAILABLE 1
+#endif
+
+#ifndef HAVE_LED
+#define HAVE_LED 1
+#endif
+#ifndef LED_OPEN_DRAIN
+#define LED_OPEN_DRAIN 1
+#endif
+#ifndef LED_GPIO_PORT
+#define LED_GPIO_PORT GPIOB
+#endif
+#ifndef LED_GPIO_PIN
+#define LED_GPIO_PIN GPIO8
+#endif
+
+#ifndef HAVE_BUTTON
+#define HAVE_BUTTON 0
+#endif
+// #ifndef BUTTON_ACTIVE_HIGH
+// #define BUTTON_ACTIVE_HIGH 0
+// #endif
+// #ifndef BUTTON_GPIO_PORT
+// #define BUTTON_GPIO_PORT GPIOA
+// #endif
+// #ifndef BUTTON_GPIO_PIN
+// #define BUTTON_GPIO_PIN GPIO0
+// #endif
+
+#ifndef BUTTON_SAMPLE_DELAY_CYCLES
+#define BUTTON_SAMPLE_DELAY_CYCLES 1440000
+#endif
+
+#ifndef HAVE_USB_PULLUP_CONTROL
+#define HAVE_USB_PULLUP_CONTROL 0
+#endif
+
+//#ifndef USES_GPIOB
+//#define USES_GPIOB 1
+//#endif
+//
+//#ifndef USES_GPIOC
+//#define USES_GPIOC 1
+//#endif
+
+#endif

--- a/src/stm32f103/stm32f103x6.ld
+++ b/src/stm32f103/stm32f103x6.ld
@@ -1,0 +1,33 @@
+/*
+ * This file is part of the libopencm3 project.
+ *
+ * Copyright (C) 2015 Karl Palsson <karlp@tweak.net.au>
+ *
+ * This library is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/* Linker script for STM32F103x8, 64k flash, 20k RAM.
+ * This script also works for the STM32F103xB and the STM32F103xC,
+ * as the bootloader only uses the first 8kB of flash. */
+
+/* Define memory regions. */
+MEMORY
+{
+	vectors (rx) : ORIGIN = 0x08000000, LENGTH = 0x150
+	rom (rx)  : ORIGIN = 0x08000150, LENGTH = 0x1EB0
+	ram (rwx) : ORIGIN = 0x20000000, LENGTH = 10K
+}
+
+/* Include the common ld script. */
+INCLUDE stm32f103/stm32f1.ld

--- a/src/stm32f103/target_stm32f103.c
+++ b/src/stm32f103/target_stm32f103.c
@@ -105,10 +105,17 @@ void target_gpio_setup(void) {
         const uint8_t conf = (LED_OPEN_DRAIN ? GPIO_CNF_OUTPUT_OPENDRAIN
                                              : GPIO_CNF_OUTPUT_PUSHPULL);
         if (LED_OPEN_DRAIN) {
+#ifdef LED_INVERT
+            gpio_clear(LED_GPIO_PORT, LED_GPIO_PIN);
+        } else {
+            gpio_set(LED_GPIO_PORT, LED_GPIO_PIN);
+        }
+#else
             gpio_set(LED_GPIO_PORT, LED_GPIO_PIN);
         } else {
             gpio_clear(LED_GPIO_PORT, LED_GPIO_PIN);
         }
+#endif
         gpio_set_mode(LED_GPIO_PORT, mode, conf, LED_GPIO_PIN);
     }
 #endif

--- a/src/stm32f103/target_stm32f103.c
+++ b/src/stm32f103/target_stm32f103.c
@@ -101,7 +101,7 @@ void target_gpio_setup(void) {
     /* Setup LEDs */
 #if HAVE_LED
     {
-        const uint8_t mode = GPIO_MODE_OUTPUT_10_MHZ;
+        const uint8_t mode = GPIO_MODE_OUTPUT_2_MHZ;
         const uint8_t conf = (LED_OPEN_DRAIN ? GPIO_CNF_OUTPUT_OPENDRAIN
                                              : GPIO_CNF_OUTPUT_PUSHPULL);
         if (LED_OPEN_DRAIN) {

--- a/src/targets.mk
+++ b/src/targets.mk
@@ -146,6 +146,12 @@ ifeq ($(TARGET),STM32L1_GENERIC)
 	ARCH			= STM32L1
 	DEFS			+= -DNDEBUG
 endif
+ifeq ($(TARGET),DAPLINK_F103C6)
+	TARGET_COMMON_DIR	:= ./stm32f103
+	TARGET_SPEC_DIR		:= ./stm32f103/daplink_f103c6
+	LDSCRIPT		:= ./stm32f103/stm32f103x6.ld
+	ARCH			= STM32F1
+endif
 
 ifndef ARCH
 $(error Unknown target $(TARGET))


### PR DESCRIPTION
Add support of DAPLink devices (new DAPLINK_F103C6 build target) from Aliexpress that use stm32f103c6.

Add an LED_INVERT option for devices that their LED use inverted polarity but not open drain.