### PR TITLE
target: Add Koshin board support

### DIFF
--- a/release.Makefile
+++ b/release.Makefile
@@ -36,6 +36,7 @@ all: dapboot-bluepill.bin \
      dapboot-bluepillplusstm32.bin \
      dapboot-bttskrminie3v2.bin \
      dapboot-bluepill-high.bin \
+     dapboot-koshin.bin \
      dapboot-maplemini-high.bin \
      dapboot-stlink-high.bin \
      dapboot-olimexstm32h103-high.bin \
@@ -156,4 +157,10 @@ dapboot-bttskrminie3v2-high-256.bin: | $(BUILD_DIR)
 	@printf "  BUILD $(@)\n"
 	$(Q)$(MAKE) TARGET=BTTSKRMINIE3V2_HIGH_256 -C src/ clean
 	$(Q)$(MAKE) TARGET=BTTSKRMINIE3V2_HIGH_256 -C src/
+	$(Q)cp src/dapboot.bin $(BUILD_DIR)/$(@)
+
+dapboot-koshin.bin: | $(BUILD_DIR)
+	@printf "  BUILD $(@)\n"
+	$(Q)$(MAKE) TARGET=KOSHIN -C src/ clean
+	$(Q)$(MAKE) TARGET=KOSHIN -C src/
 	$(Q)cp src/dapboot.bin $(BUILD_DIR)/$(@)

--- a/src/stm32f103/bluepill/config.h
+++ b/src/stm32f103/bluepill/config.h
@@ -38,6 +38,9 @@
 #ifndef HAVE_LED
 #define HAVE_LED 1
 #endif
+#ifndef LED_ACTIVE_HIGH
+#define LED_ACTIVE_HIGH 0
+#endif
 #ifndef LED_OPEN_DRAIN
 #define LED_OPEN_DRAIN 1
 #endif
@@ -79,6 +82,11 @@
 
 #ifndef USES_GPIOC
 #define USES_GPIOC 1
+#endif
+
+
+#ifndef USES_HSE_12M
+#define USES_HSE_12M 0
 #endif
 
 #endif

--- a/src/stm32f103/bluepillplus-gd32/config.h
+++ b/src/stm32f103/bluepillplus-gd32/config.h
@@ -38,6 +38,9 @@
 #ifndef HAVE_LED
 #define HAVE_LED 1
 #endif
+#ifndef LED_ACTIVE_HIGH
+#define LED_ACTIVE_HIGH 0
+#endif
 #ifndef LED_OPEN_DRAIN
 #define LED_OPEN_DRAIN 0
 #endif
@@ -76,6 +79,11 @@
 #endif
 #ifndef USES_GPIOB
 #define USES_GPIOB 1
+#endif
+
+
+#ifndef USES_HSE_12M
+#define USES_HSE_12M 0
 #endif
 
 #endif

--- a/src/stm32f103/bluepillplus/config.h
+++ b/src/stm32f103/bluepillplus/config.h
@@ -38,6 +38,9 @@
 #ifndef HAVE_LED
 #define HAVE_LED 1
 #endif
+#ifndef LED_ACTIVE_HIGH
+#define LED_ACTIVE_HIGH 0
+#endif
 #ifndef LED_OPEN_DRAIN
 #define LED_OPEN_DRAIN 0
 #endif
@@ -76,6 +79,11 @@
 #endif
 #ifndef USES_GPIOB
 #define USES_GPIOB 1
+#endif
+
+
+#ifndef USES_HSE_12M
+#define USES_HSE_12M 0
 #endif
 
 #endif

--- a/src/stm32f103/generic/config.h
+++ b/src/stm32f103/generic/config.h
@@ -69,4 +69,8 @@
 #define HAVE_USB_PULLUP_CONTROL 0
 #endif
 
+#ifndef USES_HSE_12M
+#define USES_HSE_12M 0
+#endif
+
 #endif

--- a/src/stm32f103/koshin/config.h
+++ b/src/stm32f103/koshin/config.h
@@ -1,0 +1,107 @@
+/*
+ * Copyright (c) 2023, Xiaoyu Hong
+ *
+ * Permission to use, copy, modify, and/or distribute this software
+ * for any purpose with or without fee is hereby granted, provided
+ * that the above copyright notice and this permission notice
+ * appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL
+ * WARRANTIES WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE
+ * AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT, INDIRECT, OR
+ * CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
+ * LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT,
+ * NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN
+ * CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ */
+
+#ifndef CONFIG_H_INCLUDED
+#define CONFIG_H_INCLUDED
+
+#ifndef APP_BASE_ADDRESS
+#define APP_BASE_ADDRESS (0x08000000 + BOOTLOADER_OFFSET)
+#endif
+#ifndef FLASH_SIZE_OVERRIDE
+#define FLASH_SIZE_OVERRIDE 0x20000
+#endif
+#ifndef FLASH_PAGE_SIZE
+#define FLASH_PAGE_SIZE  1024
+#endif
+#ifndef DFU_UPLOAD_AVAILABLE
+#define DFU_UPLOAD_AVAILABLE 1
+#endif
+#ifndef DFU_DOWNLOAD_AVAILABLE
+#define DFU_DOWNLOAD_AVAILABLE 1
+#endif
+
+#ifndef HAVE_LED
+#define HAVE_LED 1
+#endif
+#ifndef LED_ACTIVE_HIGH
+#define LED_ACTIVE_HIGH 1
+#endif
+#ifndef LED_OPEN_DRAIN
+#define LED_OPEN_DRAIN 0
+#endif
+#ifndef LED_GPIO_PORT
+#define LED_GPIO_PORT GPIOB
+#endif
+#ifndef LED_GPIO_PIN
+#define LED_GPIO_PIN GPIO5
+#endif
+
+#ifndef HAVE_BUTTON
+#define HAVE_BUTTON 1
+#endif
+#ifndef BUTTON_ACTIVE_HIGH
+#define BUTTON_ACTIVE_HIGH 1
+#endif
+#ifndef BUTTON_GPIO_PORT
+#define BUTTON_GPIO_PORT GPIOB
+#endif
+#ifndef BUTTON_GPIO_PIN
+#define BUTTON_GPIO_PIN GPIO2
+#endif
+
+#ifndef BUTTON_USES_PULL
+#define BUTTON_USES_PULL 0
+#endif
+
+#ifndef BUTTON_SAMPLE_DELAY_CYCLES
+#define BUTTON_SAMPLE_DELAY_CYCLES 1440000
+#endif
+
+#ifndef HAVE_USB_PULLUP_CONTROL
+#define HAVE_USB_PULLUP_CONTROL 1
+#endif
+#ifndef USB_PULLUP_GPIO_PORT
+#define USB_PULLUP_GPIO_PORT GPIOA
+#endif
+#ifndef USB_PULLUP_GPIO_PIN
+#define USB_PULLUP_GPIO_PIN  GPIO15
+#endif
+#ifndef USB_PULLUP_ACTIVE_HIGH
+#define USB_PULLUP_ACTIVE_HIGH 1
+#endif
+#ifndef USB_PULLUP_OPEN_DRAIN
+#define USB_PULLUP_OPEN_DRAIN 0
+#endif
+
+#ifndef USES_GPIOA
+#define USES_GPIOA 1
+#endif
+
+#ifndef USES_GPIOB
+#define USES_GPIOB 1
+#endif
+
+#ifndef USES_GPIOC
+#define USES_GPIOC 1
+#endif
+
+#ifndef USES_HSE_12M
+#define USES_HSE_12M 1
+#endif
+
+#endif

--- a/src/stm32f103/maplemini/config.h
+++ b/src/stm32f103/maplemini/config.h
@@ -35,6 +35,9 @@
 #ifndef HAVE_LED
 #define HAVE_LED 1
 #endif
+#ifndef LED_ACTIVE_HIGH
+#define LED_ACTIVE_HIGH 0
+#endif
 #ifndef LED_GPIO_PORT
 #define LED_GPIO_PORT GPIOB
 #endif
@@ -78,6 +81,11 @@
 #endif
 #ifndef USES_GPIOC
 #define USES_GPIOC 0
+#endif
+
+
+#ifndef USES_HSE_12M
+#define USES_HSE_12M 0
 #endif
 
 #endif

--- a/src/stm32f103/olimexstm32h103/config.h
+++ b/src/stm32f103/olimexstm32h103/config.h
@@ -35,6 +35,9 @@
 #ifndef HAVE_LED
 #define HAVE_LED 1
 #endif
+#ifndef LED_ACTIVE_HIGH
+#define LED_ACTIVE_HIGH 0
+#endif
 #ifndef LED_GPIO_PORT
 #define LED_GPIO_PORT GPIOC
 #endif
@@ -89,6 +92,10 @@
 #endif
 #ifndef USES_GPIOC
 #define USES_GPIOC 1
+#endif
+
+#ifndef USES_HSE_12M
+#define USES_HSE_12M 0
 #endif
 
 #endif

--- a/src/stm32f103/skrminie3v2/config.h
+++ b/src/stm32f103/skrminie3v2/config.h
@@ -40,6 +40,9 @@
 #ifndef HAVE_LED
 #define HAVE_LED 1
 #endif
+#ifndef LED_ACTIVE_HIGH
+#define LED_ACTIVE_HIGH 0
+#endif
 #ifndef LED_OPEN_DRAIN
 #define LED_OPEN_DRAIN 0
 #endif
@@ -102,6 +105,10 @@
 
 #ifndef USB_DFU_ALTN
 #define USB_DFU_ALTN 2
+#endif
+
+#ifndef USES_HSE_12M
+#define USES_HSE_12M 0
 #endif
 
 #endif

--- a/src/stm32f103/stlink/config.h
+++ b/src/stm32f103/stlink/config.h
@@ -38,6 +38,9 @@
 #ifndef HAVE_LED
 #define HAVE_LED 1
 #endif
+#ifndef LED_ACTIVE_HIGH
+#define LED_ACTIVE_HIGH 0
+#endif
 #ifndef LED_GPIO_PORT
 #define LED_GPIO_PORT GPIOA
 #endif
@@ -58,6 +61,10 @@
 
 #ifndef USES_GPIOA
 #define USES_GPIOA 1
+#endif
+
+#ifndef USES_HSE_12M
+#define USES_HSE_12M 0
 #endif
 
 #endif

--- a/src/stm32f103/target_stm32f103.c
+++ b/src/stm32f103/target_stm32f103.c
@@ -70,12 +70,26 @@ void target_clock_setup(void) {
        it's better than nothing. */
     rcc_clock_setup_in_hsi_out_48mhz();
 #else
+    /* Set system clock to 72 MHz from an external crystal */
 #ifdef USES_HSE_12M
     rcc_clock_setup_in_hse_12mhz_out_72mhz();
 #else
-    /* Set system clock to 72 MHz from an external crystal */
     rcc_clock_setup_in_hse_8mhz_out_72mhz();
 #endif
+
+#endif
+}
+
+void target_pre_main(void) {
+    /* At least disable LEDs */
+#if HAVE_LED
+    {
+        if (LED_OPEN_DRAIN || LED_ACTIVE_HIGH) {
+            gpio_clear(LED_GPIO_PORT, LED_GPIO_PIN);
+        } else {
+            gpio_set(LED_GPIO_PORT, LED_GPIO_PIN);
+        }
+    }
 #endif
 }
 
@@ -102,6 +116,7 @@ void target_gpio_setup(void) {
     }
 #endif
 
+    /* Disable JTAG if PA15 are used for another purpose */
 #if (HAVE_USB_PULLUP_CONTROL && USB_PULLUP_GPIO_PORT == GPIOA && \
         (USB_PULLUP_GPIO_PIN == GPIO15))
     {

--- a/src/targets.mk
+++ b/src/targets.mk
@@ -20,6 +20,12 @@ ifeq ($(TARGET),STM32F103)
 	LDSCRIPT			:= ./stm32f103/stm32f103x8.ld
 	ARCH				= STM32F1
 endif
+ifeq ($(TARGET),KOSHIN)
+	TARGET_COMMON_DIR	:= ./stm32f103
+	TARGET_SPEC_DIR		:= ./stm32f103/koshin
+	LDSCRIPT			:= ./stm32f103/stm32f103x8.ld
+	ARCH				= STM32F1
+endif
 ifeq ($(TARGET),BLUEPILL)
 	TARGET_COMMON_DIR	:= ./stm32f103
 	TARGET_SPEC_DIR		:= ./stm32f103/bluepill


### PR DESCRIPTION
Koshin is our new STM32F103-based universal opensource debugger, which features 1.8V to 5V level shifter and two serial interfaces partially supports IEEE 1149.7 and ARM Coresight interface at very reasonable cost (less than 6$).