### PR TITLE
Make LED blinking

### DIFF
--- a/src/dfu.c
+++ b/src/dfu.c
@@ -395,3 +395,7 @@ void dfu_setup(usbd_device* usbd_dev,
         on_state_change(current_dfu_state);
     }
 }
+
+bool dfu_is_idle(void){
+    return current_dfu_state == STATE_DFU_IDLE;
+}

--- a/src/dfu.h
+++ b/src/dfu.h
@@ -38,4 +38,6 @@ extern void dfu_setup(usbd_device* usbd_dev,
                       StateChangeCallback on_state_change,
                       StatusChangeCallback on_status_change);
 
+bool dfu_is_idle (void);
+
 #endif


### PR DESCRIPTION
For stm32f103 devices, if LED was enable, make LED blinking: slow pattern when DFU is idle, otherwise, fast pattern is used.